### PR TITLE
fix iviSans font-faces to multiply font-weight

### DIFF
--- a/src/shared/assets/fonts/index.scss
+++ b/src/shared/assets/fonts/index.scss
@@ -4,21 +4,21 @@
 }
 
 @font-face {
-  font-family: iviSansRegular;
+  font-family: iviSans;
   src: url(./iviSans-Regular.woff2);
   font-weight: 400;
   font-style: normal;
 }
 
 @font-face {
-  font-family: iviSansMedium;
+  font-family: iviSans;
   src: url(./iviSans-Medium.woff2);
   font-weight: 500;
   font-style: normal;
 }
 
 @font-face {
-  font-family: iviSansBold;
+  font-family: iviSans;
   src: url(./iviSans-Bold.woff2);
   font-weight: 700;
   font-style: normal;


### PR DESCRIPTION
Исправила  iviSans font-face, теперь font-family один (iviSans) а чтобы указать weight шрифта просто используем  font-weight: 400 или 500 или 700 внутри селектора.

Это оказалось проще, чем я думала.