### PR TITLE
Для обсуждения, пример того как использовать глобальные scss стили

### DIFF
--- a/src/app-fsd/styles/global.scss
+++ b/src/app-fsd/styles/global.scss
@@ -1,5 +1,4 @@
 @import "./reset.scss";
-@import "@/shared/index.scss";
 
 html {
   font-family: iviSans;

--- a/src/pages-fsd/MainPage/MainPage.tsx
+++ b/src/pages-fsd/MainPage/MainPage.tsx
@@ -2,6 +2,7 @@ import { FC } from "react";
 import Link from "next/link";
 import cn from "classnames";
 import { BannerSlider, MovieSelectionByType } from "@/widgets";
+import { ExpandedBlock } from "@/shared/ui/ExpandedBlock/ExpandedBlock";
 import styles from "./MainPage.module.scss";
 
 export const MainPage: FC = () => (
@@ -23,6 +24,12 @@ export const MainPage: FC = () => (
         </Link>
       </section>
       <MovieSelectionByType type="Movie selector type" />
+      <ExpandedBlock
+        content={
+          "Случалось ли вам отказаться от просмотра интересного фильма из-за того, что его показывали в неудобное время? Приходилось ли искать в сети интернет, где смотреть фильмы онлайн? А спорить с домашними из-за выбора кино для просмотра по ТВ? \n Все эти проблемы остались в прошлом! Откройте для себя фильмы онлайн в HD-качестве с кинотеатром Иви. Мы не просто освобождаем вас от необходимости идти в кинотеатр или изучать программу телепередач – у посетителей нашего ресурса гораздо больше возможностей."
+        }
+        title="Онлайн-кинотеатр Иви: фильмы в хорошем качестве всегда приносят настоящее удовольствие"
+      />
     </div>
   </div>
 );

--- a/src/shared/ui/ExpandedBlock/ExpandedBlock.module.scss
+++ b/src/shared/ui/ExpandedBlock/ExpandedBlock.module.scss
@@ -1,0 +1,53 @@
+// Импорт глобальных переменных, шрифтов, глобальных стилей
+@import "../../index.scss";
+
+// --------Expanded block style-------- //
+.expandedBlock {
+  color: $color-sofia;
+  line-height: 22px;
+  font-family: iviSans;
+  line-height: 22px;
+}
+
+.title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.content {
+  margin-top: 12px;
+  color: $color-axum;
+  display: block;
+  font-size: 15px;
+  font-weight: 400;
+}
+
+.paragraph {
+  &:not(:first-child) {
+    margin-top: 8px;
+  }
+}
+
+.hidden {
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  display: block;
+  display: -webkit-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.button {
+  color: $color-sofia;
+  margin-top: 8px;
+  font-size: 15px;
+  font-weight: 500;
+  opacity: 0.8;
+  cursor: pointer;
+  transition: all 0.3s;
+
+  &:hover {
+    opacity: 1;
+  }
+}

--- a/src/shared/ui/ExpandedBlock/ExpandedBlock.stories.tsx
+++ b/src/shared/ui/ExpandedBlock/ExpandedBlock.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import "../../../app-fsd/index.scss";
+import { ExpandedBlock } from "./ExpandedBlock";
+
+const meta: Meta<typeof ExpandedBlock> = {
+  title: "UI/ExpandedBlock",
+  component: ExpandedBlock,
+  tags: ["autodocs"],
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ExpandedBlock>;
+
+export const Primary: Story = {
+  args: {
+    title:
+      "Онлайн-кинотеатр Иви: фильмы в хорошем качестве всегда приносят настоящее удовольствие",
+    content:
+      "Случалось ли вам отказаться от просмотра интересного фильма из-за того, что его показывали в неудобное время? Приходилось ли искать в сети интернет, где смотреть фильмы онлайн? А спорить с домашними из-за выбора кино для просмотра по ТВ? \n Все эти проблемы остались в прошлом! Откройте для себя фильмы онлайн в HD-качестве с кинотеатром Иви. Мы не просто освобождаем вас от необходимости идти в кинотеатр или изучать программу телепередач – у посетителей нашего ресурса гораздо больше возможностей.",
+  },
+};

--- a/src/shared/ui/ExpandedBlock/ExpandedBlock.test.tsx
+++ b/src/shared/ui/ExpandedBlock/ExpandedBlock.test.tsx
@@ -1,0 +1,41 @@
+import { screen, fireEvent, render } from "@testing-library/react";
+import { ExpandedBlock } from "./ExpandedBlock";
+
+describe("ExpandedBlock test", () => {
+  it("ExpandedBlock rendered!", () => {
+    render(<ExpandedBlock title="title" content="content" />);
+
+    const element: HTMLElement = screen.getByTestId("expandedBlock");
+
+    expect(element).toBeInTheDocument();
+  });
+
+  test("clicks toggle class 'hidden'", () => {
+    render(<ExpandedBlock title="title" content="content" />);
+
+    const button: HTMLElement = screen.getByRole("button");
+    const content: HTMLElement = screen.getByTestId("content");
+
+    expect(content).toHaveClass("hidden");
+    fireEvent.click(button);
+    expect(content).not.toHaveClass("hidden");
+    fireEvent.click(button);
+    expect(content).toHaveClass("hidden");
+  });
+
+  test("split content text to paragraphs", () => {
+    const paragraphsArray = [
+      "Lorem ipsum.",
+      "Pellentesque felis",
+      "Quisque varius.",
+    ];
+
+    const contentText = paragraphsArray.join("\n");
+
+    render(<ExpandedBlock title="Lorem ipsum" content={contentText} />);
+
+    const paragraphs: HTMLElement[] = screen.getAllByTestId("paragraph");
+
+    expect(paragraphs.length).toEqual(3);
+  });
+});

--- a/src/shared/ui/ExpandedBlock/ExpandedBlock.tsx
+++ b/src/shared/ui/ExpandedBlock/ExpandedBlock.tsx
@@ -1,0 +1,35 @@
+import React, { FC, useState } from "react";
+import cn from "classnames";
+import styles from "./ExpandedBlock.module.scss";
+
+interface ExpandedBlockProps {
+  title: string;
+  content: string;
+}
+
+export const ExpandedBlock: FC<ExpandedBlockProps> = ({ title, content }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const toggleBlock = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  return (
+    <div className={styles.expandedBlock} data-testid="expandedBlock">
+      <h2 className={styles.title}>{title}</h2>
+      <div
+        className={cn(styles.content, !isExpanded && styles.hidden)}
+        data-testid="content"
+      >
+        {content.split("\n").map((paragraph, i) => (
+          <p key={i} className={styles.paragraph} data-testid="paragraph">
+            {paragraph}
+          </p>
+        ))}
+      </div>
+      <button className={styles.button} onClick={toggleBlock}>
+        {!isExpanded ? "Развернуть" : "Свернуть"}
+      </button>
+    </div>
+  );
+};


### PR DESCRIPTION
Проблема: на днях мы договорили что основные стили и **reset.scss** из app-fsd переедут в shared (сейчас там fonts, vars, mixins, templates)

Предполагается что импорт из shared/index.scss использовался бы в scss модулях компонентов, но reset.scss использует такие селекторы которые в scss модулях не могут применяться (* {}, button {} - неоднозначные селекторы без класса или id), поэтому их в модули импортировать нельзя.

Мое решение оставить примерно как есть разделить стили на две группы: 
1. app-fsd/index.js - там будут global.scss и reset.scss  (отсюда импортировать в приложение и сторизы)
2. shared/index.scss  - там будут vars.scss, fonts.scss, templates.scss, mixins.scss (отсюда импортировать в scss модули)

ниже подробнее комменты на примере что и где я использовала.

хотя PR для демонстрации, если смысл устраивает, можно его принять так как, мне кажется, изменения по делу